### PR TITLE
rename concept of song sheet to chord sheet across entire app

### DIFF
--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -55,6 +55,6 @@ class SongsController < ApplicationController
 
   private
   def song_params
-    params.require(:song).permit(:name, :key, :artist, :tempo, :song_sheet)
+    params.require(:song).permit(:name, :key, :artist, :tempo, :chord_sheet)
   end
 end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -3,7 +3,7 @@ class Song < ActiveRecord::Base
   include PgSearch
   pg_search_scope(
     :search_by_keywords, 
-    against: {name: 'A', song_sheet: 'B', artist: 'B'},
+    against: {name: 'A', chord_sheet: 'B', artist: 'B'},
     using: {:tsearch => {any_word: true, prefix: true}}
   )
 
@@ -13,7 +13,7 @@ class Song < ActiveRecord::Base
   VALID_TEMPOS = %w(Fast Medium Slow)
 
   validates :name, presence: true
-  validates :song_sheet, presence: true
+  validates :chord_sheet, presence: true
   validates_inclusion_of :key, in: VALID_KEYS, allow_nil: true
   validates_inclusion_of :tempo, in: VALID_TEMPOS, allow_nil: true
   before_save :normalize

--- a/app/views/songs/_form.html.erb
+++ b/app/views/songs/_form.html.erb
@@ -24,8 +24,8 @@
   </div>
 
   <div class="form-group">
-    <%= f.label :song_sheet %><br/>
-    <%= f.text_area :song_sheet, class: 'form-control' %>
+    <%= f.label :chord_sheet %><br/>
+    <%= f.text_area :chord_sheet, class: 'form-control' %>
   </div>
 
   <%= f.submit 'Upload', class: 'btn btn-default' %>

--- a/db/migrate/20160905214718_rename_song_sheet_to_chord_sheet.rb
+++ b/db/migrate/20160905214718_rename_song_sheet_to_chord_sheet.rb
@@ -1,0 +1,5 @@
+class RenameSongSheetToChordSheet < ActiveRecord::Migration
+  def change
+    rename_column :songs, :song_sheet, :chord_sheet
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160803224917) do
+ActiveRecord::Schema.define(version: 20160905214718) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,18 +28,18 @@ ActiveRecord::Schema.define(version: 20160803224917) do
   add_index "song_tags", ["tag_id"], name: "index_song_tags_on_tag_id", using: :btree
 
   create_table "songs", force: :cascade do |t|
-    t.string   "name",                 null: false
-    t.string   "key",        limit: 2
+    t.string   "name",                  null: false
+    t.string   "key",         limit: 2
     t.string   "artist"
-    t.text     "song_sheet",           null: false
-    t.datetime "created_at",           null: false
-    t.datetime "updated_at",           null: false
+    t.text     "chord_sheet",           null: false
+    t.datetime "created_at",            null: false
+    t.datetime "updated_at",            null: false
     t.string   "tempo"
   end
 
   add_index "songs", ["artist"], name: "index_songs_on_artist", using: :gin
+  add_index "songs", ["chord_sheet"], name: "index_songs_on_chord_sheet", using: :gin
   add_index "songs", ["name"], name: "index_songs_on_name", using: :gin
-  add_index "songs", ["song_sheet"], name: "index_songs_on_song_sheet", using: :gin
 
   create_table "tags", force: :cascade do |t|
     t.string   "name",       null: false

--- a/test/controllers/songs_controller_test.rb
+++ b/test/controllers/songs_controller_test.rb
@@ -81,7 +81,7 @@ class SongsControllerTest < ActionController::TestCase
   end
 
   def post_new_song_form
-    post :create, song: {name: "New Song Just Posted", key: "E", artist: "New Song Artist", tempo: "Fast", song_sheet: "New Song Chords"}
+    post :create, song: {name: "New Song Just Posted", key: "E", artist: "New Song Artist", tempo: "Fast", chord_sheet: "New Song Chords"}
   end
 
 end

--- a/test/fixtures/songs.yml
+++ b/test/fixtures/songs.yml
@@ -9,7 +9,7 @@ God_be_praised:
   artist: "Elevation Worship"
   key: "D"
   tempo: "Slow"
-  song_sheet: |
+  chord_sheet: |
     VERSE 1
                     G               D
     You left Your throne for our salvation
@@ -69,7 +69,7 @@ forever_reign:
   artist: "Hillsong Worship"
   key: "C"
   tempo: "Medium"
-  song_sheet: |
+  chord_sheet: |
     VERSE 1
               C
     You are good, You are good
@@ -146,7 +146,7 @@ ten_thousand_reasons:
   artist: "Matt Redman"
   key: "G"
   tempo: "Medium"
-  song_sheet: |
+  chord_sheet: |
     CHORUS
               F          C     G/B Am
     Bless the Lord, O my soul, O my soul
@@ -191,7 +191,7 @@ glorious_day:
   artist: "Casting Crowns"
   key: "B"
   tempo: "Medium"
-  song_sheet: |
+  chord_sheet: |
     VERSE 1
      B             E                           B
     One day when Heaven was filled with His praises
@@ -264,7 +264,7 @@ hands_to_the_heaven:
   artist: "Kari Jobe"
   key: "F#"
   tempo: "Fast"
-  song_sheet: |
+  chord_sheet: |
     VERSE 1
     D#m B         F#
     We are your church
@@ -316,7 +316,7 @@ all_my_hope:
   artist: "Hillsong Worship"
   key: "C"
   tempo: "Medium"
-  song_sheet: |
+  chord_sheet: |
     VERSE 1
     Gb                        Db
     Peace be still, You are near
@@ -367,13 +367,13 @@ all_my_hope:
 
 relevant_1:
   name: "relevant"
-  song_sheet: "lyrics go here"
+  chord_sheet: "lyrics go here"
 relevant_2:
   name: "not very"
-  song_sheet: "relevant relevant"
+  chord_sheet: "relevant relevant"
 relevant_3:
   name: "even less"
-  song_sheet: "relevant"
+  chord_sheet: "relevant"
 relevant_4:
   name: "not at all"
-  song_sheet: "lyrics go here"
+  chord_sheet: "lyrics go here"

--- a/test/models/song_test.rb
+++ b/test/models/song_test.rb
@@ -19,10 +19,10 @@ class SongTest < ActiveSupport::TestCase
     assert_not song.save, "Saved with an invalid tempo"
   end
 
-  test "should not save without a song sheet" do
+  test "should not save without a chord sheet" do
     song = songs(:God_be_praised)
-    song.song_sheet = nil
-    assert_not song.save, "Saved without a song sheet"
+    song.chord_sheet = nil
+    assert_not song.save, "Saved without a chord sheet"
   end
 
   test "normalizes name and artist" do


### PR DESCRIPTION
@leethomas Can you review this one as well? I've been meaning to rename song sheet to chord sheet for better nomenclature, as chord sheet is what most praise people call a piece of paper with lyrics and chords on it. It also makes more sense intuitively as the chord sheet does not contain either the song name or song metadata, while song sheet would imply it does.