### PR TITLE
feat: allow acts2.network domain email addresses

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,5 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"], {
-    hd: "gpmail.org" # restrict logins to only Gpmail accounts
+    hd: %w(gpmail.org acts2.network) # restrict logins to only gpmail.org or acts2.network accounts
   }
 end


### PR DESCRIPTION
Update the oauth configuration to allow `acts2.network` domain accounts in addition to `gpmail.org`.

Background: people are getting moved over to `acts2.network` in batches, so it'd be great to support that domain too.

Sorry I didn't test this in any way, but it seems like the right config change based on the OmniAuth documentation. Please modify if this is not right!